### PR TITLE
docs: fix cruft command reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The template will ask for the following:
 To create a project, aka bake a cookie 🍪, using [uv](https://docs.astral.sh/uv/) and cruft:
 
 ```
-uvx cruft git@github.com:tekumara/python-typed-template.git
+uvx cruft create git@github.com:tekumara/python-typed-template.git
 # replace repo-name below with the name you specified during template creation
 cd repo-name
 git init && git commit -m 'root commit' --allow-empty


### PR DESCRIPTION
In cruft 2.16.0 (latest) using current command:
```
❯ uvx cruft git@github.com:tekumara/python-typed-template.git
Usage: cruft [OPTIONS] COMMAND [ARGS]...
Try 'cruft --help' for help.
╭─ Error
No such command 'git@github.com:tekumara/python-typed-template.git'.                                    
```

Need to use `cruft create`